### PR TITLE
Create ASDF system definition for clifford package.

### DIFF
--- a/clifford.asd
+++ b/clifford.asd
@@ -1,0 +1,10 @@
+(defsystem clifford
+  :defsystem-depends-on ("maxima-file")
+  :name "clifford"
+  :author "Dimiter Prodanov"
+  :licence "GNU Lesser General Public License, version 2.1"
+  :description "a lightweight package for performing Geometric and Clifford Algebra calculations"
+
+  :components
+    ((:maxima-file "clifford")
+     (:maxima-file "cliffordan")))


### PR DESCRIPTION
This pull request includes an ASDF system definition, clifford.asd, which makes it possible for Maxima + Quicklisp + ASDF to load clifford. 

In order to make use of this, you must have the maxima-asdf Lisp files from: https://github.com/robert-dodier/maxima-asdf
Follow the instructions in the README.md there. The only difference is that you would write: `install_github("dprodanov", "clifford", "master");` to fetch the code from your own repository instead of mine (i.e. "robert-dodier"). 
